### PR TITLE
Fix PM2.5 value always reporting as 0

### DIFF
--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -443,8 +443,8 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
 
       pm25NAN = (payload[12] == 0xFF && payload[13] == 0xFF);
       if (!pm25NAN) {
-        uint16_t raw_value = (payload[13] << 8) + payload[12];
-        uint32_t new_pm25Value = (raw_value * 10) / 10000;
+        uint16_t new_pm25Value = (payload[13] << 8) + payload[12];
+        //uint32_t new_pm25Value = (raw_value * 10) / 10000;
         
         if (new_pm25Value != pm25_value) {
           pm25Change = true;

--- a/components/levoit/sensor/levoit_sensor.cpp
+++ b/components/levoit/sensor/levoit_sensor.cpp
@@ -26,11 +26,7 @@ void LevoitSensor::setup() {
             this->publish_state(NAN);
             this->parent_->set_request_state(0, static_cast<uint32_t>(LevoitState::PM25_NAN), false);
           } else {
-            uint16_t integer_part = this->parent_->pm25_value / 10;
-            uint16_t decimal_part = this->parent_->pm25_value % 10;
-            float pm25Publish = integer_part + (decimal_part / 10.0);
-
-            this->publish_state(pm25Publish);
+            this->publish_state(this->parent_->pm25_value);
             this->parent_->set_request_state(0, static_cast<uint32_t>(LevoitState::PM25_CHANGE), false);
           }
         }


### PR DESCRIPTION
This patch corrects the PM2.5 parsing logic for Levoit purifiers. The original implementation scaled the raw value down by dividing by 10,000, which caused nearly all real-world readings to truncate to zero.

The fix removes the unnecessary scaling and instead uses the raw 16-bit PM2.5 value directly, matching what is shown on the purifier's display (µg/m³).